### PR TITLE
Remove python.pythonPath

### DIFF
--- a/host_vars/localhost/vscode.yml
+++ b/host_vars/localhost/vscode.yml
@@ -74,7 +74,6 @@ vscode_users:
         "workbench.colorTheme": "Night Owl Black",
         "workbench.settings.editor": "json",
         "workbench.sideBar.location": "right",
-        "python.pythonPath": "/usr/bin/python3",
         "python.linting.enabled": true,
         "python.linting.mypyEnabled": true,
         "python.linting.flake8Enabled": true,


### PR DESCRIPTION
This isn't actually used by anything.